### PR TITLE
Add email link to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -45,6 +45,26 @@
             ></path>
           </svg>
         </a>
+        <a
+          href="mailto:hinojosa.rub@gmail.com"
+          class="text-gray-400 hover:text-white transition-colors"
+        >
+          <span class="sr-only">Email</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              d="M2.003 5.884L12 12.856l9.997-6.972A2 2 0 0020 4H4a2 2 0 00-1.997 1.884z"
+            ></path>
+            <path
+              d="M22 6.986l-10 6.998-10-6.998V18a2 2 0 002 2h16a2 2 0 002-2V6.986z"
+            ></path>
+          </svg>
+        </a>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a mailto link in the footer with an envelope icon

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687525870da0832c8b0287b451118a2a